### PR TITLE
Fixed 500 error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:system",
+    "python-envs.pythonProjects": []
+}

--- a/HeroHours/views.py
+++ b/HeroHours/views.py
@@ -134,15 +134,16 @@ def handle_bulk_updates(user_id, time = None):
             if not user.Last_In:
                 user.Last_In = time
             user.Checked_In = False
-            user.Total_Hours = ExpressionWrapper(F('Total_Hours') + (time - user.Last_In),
-                                                 output_field=DurationField())
-            user.Total_Seconds = F('Total_Seconds') + round((time - user.Last_In).total_seconds())
+            # Calculate actual values instead of using F() expressions
+            time_diff = time - user.Last_In
+            user.Total_Hours = user.Total_Hours + time_diff
+            user.Total_Seconds = user.Total_Seconds + round(time_diff.total_seconds())
             user.Last_Out = time
 
         updated_log.append(log)
         updated_users.append(user)
 
-    models.Users.objects.bulk_update(updated_users, ["Checked_In", "Total_Hours", "Total_Seconds", "Last_Out"])
+    models.Users.objects.bulk_update(updated_users, ["Checked_In", "Total_Hours", "Total_Seconds", "Last_Out", "Last_In"])
     models.ActivityLog.objects.bulk_create(updated_log)
     elapsed_time = time.time() - start_time
     print(f"input(bulk) execution time: {elapsed_time:.4f} seconds")
@@ -235,3 +236,4 @@ def sheet_pull(request):
     for member in members:
         response += f"{member.User_ID},{member.First_Name},{member.Last_Name},{member.get_total_hours()},{member.Total_Seconds},{member.Last_In},{member.Last_Out},{member.Is_Active}\n"
     return HttpResponse(response,content_type='text/csv')
+    


### PR DESCRIPTION
I believe I fixed the 500 error mentioned in #57, which happened when we tried to sign everyone out at once. The problem was that the code used Django’s F-expressions to update everyone’s hours and seconds in bulk, but F-expressions don’t work correctly when modifying objects in memory before saving them with `bulk_update`. Because F-expressions are meant for direct database updates, using them this way caused a server error (500) during mass sign-out.

I made it so it calculates the new hours and seconds for each user in Python first, so the fields now have proper values when we run the bulk update that clocks out everyone still clocked in at the end of a meeting. This ensures the data gets saved without errors, and mass sign-out now works reliably. Basically everything was ruined bc of a stupid edge case of someone not having a sign in time. You get your "Cha-Ching!", Michael.

@mstatistics 